### PR TITLE
Fix typo in Expiration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ expiration_time = Tus::Server.opts[:expiration_time]
 tus_storage     = Tus::Server.opts[:storage]
 expiration_date = Time.now.utc - expiration_time
 
-tus_storage.expire_files(expiration_time)
+tus_storage.expire_files(expiration_date)
 ```
 
 ## Download


### PR DESCRIPTION
I think there is a typo in the Expiration section.
As `expire_files` [accepts the date](https://github.com/janko/tus-ruby-server/blob/7a332e1/lib/tus/storage/s3.rb#L208), not the time.

I just wanted to update this in case of any confusion when copying from the docs.