### PR TITLE
Add Access-Control-Allow-Headers

### DIFF
--- a/features/cors.feature
+++ b/features/cors.feature
@@ -10,7 +10,7 @@ Feature: CORS
       """
       Access-Control-Allow-Origin: tus-server.org
       Access-Control-Allow-Methods: POST, GET, HEAD, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat
+      Access-Control-Allow-Headers: Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat
       Access-Control-Max-Age: 86400
       """
 

--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -396,7 +396,7 @@ module Tus
 
       if request.options?
         response.headers["Access-Control-Allow-Methods"] = "POST, GET, HEAD, PATCH, DELETE, OPTIONS"
-        response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat"
+        response.headers["Access-Control-Allow-Headers"] = "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat"
         response.headers["Access-Control-Max-Age"]       = "86400"
       else
         response.headers["Access-Control-Expose-Headers"] = "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat"


### PR DESCRIPTION
Passing Authorization headers from client to tus-ruby-server was causing upload failures. 

![image](https://user-images.githubusercontent.com/22564608/80923581-7c858980-8d39-11ea-9c62-5ff780d81aa1.png)

The tusd GO server implementation included additional headers omitted in this implementation. I'm just getting started with the Tus protocol so there may be something else at play, but allowing additional headers fixes the issues. 