### PR TITLE
Make S3 content disposition option dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ a `:prefix` in the storage configuration.
 Tus::Storage::S3.new(prefix: "tus", **options)
 ```
 
-You can also specify additional options that will be fowarded to
+You can also specify additional options that will be forwarded to
 [`Aws::S3::Client#create_multipart_upload`] using `:upload_options`.
 
 ```rb

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ You can also specify additional options that will be forwarded to
 [`Aws::S3::Client#create_multipart_upload`] using `:upload_options`.
 
 ```rb
-Tus::Storage::S3.new(upload_options: { acl: "public-read" }, **options)
+Tus::Storage::S3.new(upload_options: { acl: "public-read", disposition: "attachment" }, **options)
 ```
 
 All other options will be forwarded to [`Aws::S3::Client#initialize`]:

--- a/lib/tus/storage/s3.rb
+++ b/lib/tus/storage/s3.rb
@@ -50,7 +50,8 @@ module Tus
 
         options = {}
         options[:content_type] = tus_info.type if tus_info.type
-        options[:content_disposition] = ContentDisposition.inline(tus_info.name) if tus_info.name
+        options[:content_disposition] = ContentDisposition.(disposition: upload_options[:disposition] || "inline", filename: tus_info.name)
+        upload_options.delete(:disposition)
         options.merge!(upload_options)
 
         multipart_upload = object(uid).initiate_multipart_upload(options)


### PR DESCRIPTION
Instead of having S3 content disposition hard coded to inline allow passing the value with the `upload_options`.