### PR TITLE
Add option to set the uploaded file name with extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,14 @@ can change it to "attachment" if you want the browser to always force download:
 Tus::Server.opts[:disposition] = "attachment"
 ```
 
+## Extension
+
+If you need the extension in the file name, you can set `:file_extension` to true, default is false.
+
+```rb
+Tus::Server.opts[:file_extension] = true
+```
+
 ## Checksum
 
 The following checksum algorithms are supported for the `checksum` extension:

--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -81,7 +81,6 @@ module Tus
           validate_upload_metadata! if request.headers["Upload-Metadata"]
           validate_upload_concat! if request.headers["Upload-Concat"]
 
-          uid  = SecureRandom.hex
           info = Tus::Info.new(
             "Upload-Length"       => request.headers["Upload-Length"],
             "Upload-Offset"       => "0",
@@ -90,6 +89,12 @@ module Tus
             "Upload-Concat"       => request.headers["Upload-Concat"],
             "Upload-Expires"      => (Time.now + expiration_time).httpdate,
           )
+
+          if opts[:file_extension]
+            uid  = "#{SecureRandom.hex}#{File.extname(info.name)}"
+          else
+            uid  = SecureRandom.hex
+          end
 
           before_create(uid, info)
 


### PR DESCRIPTION
When you need to download or preview the files directly from the storage you will have the issue that the files have no extensions. My solution is to simple have an option to keep the file extension `Tus::Server.opts[:file_extension] = true`.