### PR TITLE
Allow setting sub-prefix from client side for S3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ a `:prefix` in the storage configuration.
 Tus::Storage::S3.new(prefix: "tus", **options)
 ```
 
+To set a subdirectory from the client side you can set `Sub-Prefix` in the HTTP headers. This can be in addition to the previous option or by its own.
+
+```js
+headers: {
+  'Sub-Prefix': 'images'
+}
+```
+
 You can also specify additional options that will be fowarded to
 [`Aws::S3::Client#create_multipart_upload`] using `:upload_options`.
 

--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -91,6 +91,8 @@ module Tus
             "Upload-Expires"      => (Time.now + expiration_time).httpdate,
           )
 
+          storage.set_sub_prefix(request.headers['Sub-Prefix'])
+
           before_create(uid, info)
 
           if info.final?
@@ -396,7 +398,7 @@ module Tus
 
       if request.options?
         response.headers["Access-Control-Allow-Methods"] = "POST, GET, HEAD, PATCH, DELETE, OPTIONS"
-        response.headers["Access-Control-Allow-Headers"] = "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat"
+        response.headers["Access-Control-Allow-Headers"] = "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Sub-Prefix"
         response.headers["Access-Control-Max-Age"]       = "86400"
       else
         response.headers["Access-Control-Expose-Headers"] = "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat"

--- a/lib/tus/storage/s3.rb
+++ b/lib/tus/storage/s3.rb
@@ -220,6 +220,14 @@ module Tus
         bucket.client
       end
 
+      def set_sub_prefix(sub_prefix)
+        if prefix
+          @prefix = "#{prefix}/#{sub_prefix}"
+        else
+          @prefix = "#{sub_prefix}"
+        end
+      end
+
       private
 
       # Uploads given body as a new multipart part with the specified part


### PR DESCRIPTION
In addition to the prefix in the s3 option we can allow the user to set prefix from the client side by setting http headers as: `headers: { 'Sub-Prefix': 'images' }`